### PR TITLE
Bump base bounds

### DIFF
--- a/seqid-streams.cabal
+++ b/seqid-streams.cabal
@@ -20,7 +20,7 @@ source-repository head
 library
   exposed-modules: System.IO.Streams.SequenceId
 
-  build-depends: base       >= 4.7 && < 4.12
+  build-depends: base       >= 4.7 && < 4.14
                , io-streams >= 1.2 && < 1.6
                , seqid      >= 0.6 && < 0.7
 

--- a/seqid-streams.cabal
+++ b/seqid-streams.cabal
@@ -1,5 +1,5 @@
 name:                seqid-streams
-version:             0.7.0.1
+version:             0.7.1
 synopsis:            Sequence ID IO-Streams
 description:         Uniquely identify elements in a sequenced stream
 License:             BSD3

--- a/seqid-streams.cabal
+++ b/seqid-streams.cabal
@@ -1,5 +1,5 @@
 name:                seqid-streams
-version:             0.7.0
+version:             0.7.0.1
 synopsis:            Sequence ID IO-Streams
 description:         Uniquely identify elements in a sequenced stream
 License:             BSD3


### PR DESCRIPTION
So that we can use 8.6.5 downstream.